### PR TITLE
fixes issues I had with helio

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -8079,6 +8079,7 @@
 	dir = 9;
 	name = "engineering yellow"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "aRj" = (
@@ -14853,7 +14854,7 @@
 /area/station/security/prison/visit)
 "brP" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Security EVAC"
+	name = "Holding Area"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16113,6 +16114,7 @@
 /area/station/service/bar)
 "bxj" = (
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bxk" = (
@@ -16373,6 +16375,7 @@
 	location = "brown";
 	name = "Patrol Beacon"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "byF" = (
@@ -16555,6 +16558,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bzp" = (
@@ -22228,29 +22232,6 @@
 /turf/open/floor/iron/textured_half,
 /area/station/cargo/warehouse)
 "cyl" = (
-/obj/structure/closet/crate/engineering/electrical,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/cable_coil,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/box,
@@ -22588,6 +22569,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/solars/starboard/aft)
 "cAR" = (
@@ -26293,6 +26275,10 @@
 /area/station/maintenance/department/science/central)
 "cWX" = (
 /obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "aftstarboard";
+	name = "Aft-Starboard Solar Array"
+	},
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/aft)
 "cXg" = (
@@ -28374,6 +28360,7 @@
 	name = "Aft Port Solars Control"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "dKY" = (
@@ -28504,6 +28491,20 @@
 /obj/effect/spawner/random/trash/caution_sign,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"dPq" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "dPM" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
@@ -47712,11 +47713,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/textured_half,
 /area/station/maintenance/department/eva/abandoned)
-"lCH" = (
-/obj/structure/lattice,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/space/nearstation)
 "lCI" = (
 /obj/machinery/modular_computer/preset/cargochat/service,
 /obj/effect/turf_decal/bot,
@@ -50814,6 +50810,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"mOe" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "mOF" = (
 /obj/structure/closet/crate/internals,
 /obj/item/tank/internals/generic,
@@ -73934,6 +73936,7 @@
 	name = "Fore Starboard Solars Control"
 	},
 /obj/structure/sign/warning/vacuum/external/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "vUB" = (
@@ -77991,10 +77994,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood,
 /area/station/maintenance/aft/lesser)
-"xBJ" = (
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/space)
 "xCy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/engine,
@@ -112687,19 +112686,19 @@ buI
 bxk
 bvs
 daF
-bwl
-caP
-bwl
-bwl
-bwl
-bwl
-bwl
-bwl
-cJN
-bJB
-bJB
-bJB
-bJB
+bjW
+ccu
+bjW
+bjW
+bjW
+bjW
+bjW
+bjW
+mOe
+bJe
+bJe
+bJe
+bJe
 bJe
 bJB
 bJB
@@ -112943,7 +112942,7 @@ bud
 edr
 bud
 bwl
-bwl
+bjW
 byE
 mTs
 sSf
@@ -113199,7 +113198,7 @@ bwl
 bwl
 gXc
 bwl
-bwl
+bjW
 bxj
 byF
 cXB
@@ -113455,8 +113454,8 @@ bev
 btg
 bwl
 gXc
-bwl
-bwl
+bjW
+bjW
 cNr
 cNr
 tdu
@@ -119620,8 +119619,8 @@ rlZ
 dsh
 igm
 bzn
-nBH
-eGq
+dPq
+aKB
 iiK
 bvu
 buR
@@ -133032,19 +133031,19 @@ xaK
 aaa
 oCj
 aaa
-lCH
-xBJ
-xBJ
-xBJ
-xBJ
+aak
+aaa
+aaa
+aaa
+aaa
 aaa
 iGq
 aaa
-xBJ
-xBJ
-xBJ
-xBJ
-lCH
+aaa
+aaa
+aaa
+aaa
+aak
 aaa
 aaR
 aaa
@@ -133547,18 +133546,18 @@ aaa
 aaR
 aak
 sOT
-cAR
 sOT
-cAR
-cAR
+sOT
+sOT
+sOT
 iGq
 lya
 cAR
 sOT
 sOT
-cAR
-cAR
-cAR
+sOT
+sOT
+sOT
 aak
 aaR
 aaa
@@ -134060,19 +134059,19 @@ aak
 aak
 oCj
 aaa
-lCH
-xBJ
-xBJ
-xBJ
-xBJ
+aak
+aaa
+aaa
+aaa
+aaa
 aaa
 iGq
 aaa
-xBJ
-xBJ
-xBJ
-xBJ
-lCH
+aaa
+aaa
+aaa
+aaa
+aak
 aaa
 aaR
 aaa

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -74578,7 +74578,6 @@
 "whH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse/upper)
 "wib" = (

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -62369,10 +62369,8 @@
 /area/station/maintenance/department/science/xenobiology)
 "rlk" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rlM" = (


### PR DESCRIPTION
## About The Pull Request

Solars are now actually connected to the solars computer
I removed the crate of solars in southeast solars and just placed them in the map because it was just the middle array that was missing and it had cables floating through space which made it look VERY bad and I didn't like it. AI SAT already has solars that need construction so I don't see the point of it.
Added cables in the hallways from grav gen to cafe & one from morgue to med hallway
Renamed "security EVAC" to "Holding Cell" to make it more consistent with what it actually is & the other sec door to command evac area.

## Why It's Good For The Game

small quick fixes that makes me hate myself less as engineering personnel on heliostation.com

## Changelog